### PR TITLE
Feature/stock scrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .idea
+data/.DS_Store

--- a/data/sp_500_constituents_as_of_20211022.csv
+++ b/data/sp_500_constituents_as_of_20211022.csv
@@ -1,0 +1,506 @@
+Symbol,Name,Sector
+MMM,3M,Industrials
+AOS,A. O. Smith,Industrials
+ABT,Abbott Laboratories,Health Care
+ABBV,AbbVie,Health Care
+ABMD,Abiomed,Health Care
+ACN,Accenture,Information Technology
+ATVI,Activision Blizzard,Communication Services
+ADM,ADM,Consumer Staples
+ADBE,Adobe,Information Technology
+AAP,Advance Auto Parts,Consumer Discretionary
+AMD,Advanced Micro Devices,Information Technology
+AES,AES Corp,Utilities
+AFL,Aflac,Financials
+A,Agilent Technologies,Health Care
+APD,Air Products & Chemicals,Materials
+AKAM,Akamai Technologies,Information Technology
+ALK,Alaska Air Group,Industrials
+ALB,Albemarle Corporation,Materials
+ARE,Alexandria Real Estate Equities,Real Estate
+ALGN,Align Technology,Health Care
+ALLE,Allegion,Industrials
+LNT,Alliant Energy,Utilities
+ALL,Allstate Corp,Financials
+GOOGL,Alphabet (Class A),Communication Services
+GOOG,Alphabet (Class C),Communication Services
+MO,Altria Group,Consumer Staples
+AMZN,Amazon,Consumer Discretionary
+AMCR,Amcor,Materials
+AEE,Ameren Corp,Utilities
+AAL,American Airlines Group,Industrials
+AEP,American Electric Power,Utilities
+AXP,American Express,Financials
+AIG,American International Group,Financials
+AMT,American Tower,Real Estate
+AWK,American Water Works,Utilities
+AMP,Ameriprise Financial,Financials
+ABC,AmerisourceBergen,Health Care
+AME,Ametek,Industrials
+AMGN,Amgen,Health Care
+APH,Amphenol,Information Technology
+ADI,Analog Devices,Information Technology
+ANSS,Ansys,Information Technology
+ANTM,Anthem,Health Care
+AON,Aon,Financials
+APA,APA Corporation,Energy
+AAPL,Apple,Information Technology
+AMAT,Applied Materials,Information Technology
+APTV,Aptiv,Consumer Discretionary
+ANET,Arista Networks,Information Technology
+AJG,Arthur J. Gallagher & Co.,Financials
+AIZ,Assurant,Financials
+T,AT&T,Communication Services
+ATO,Atmos Energy,Utilities
+ADSK,Autodesk,Information Technology
+ADP,Automatic Data Processing,Information Technology
+AZO,AutoZone,Consumer Discretionary
+AVB,AvalonBay Communities,Real Estate
+AVY,Avery Dennison,Materials
+BKR,Baker Hughes,Energy
+BLL,Ball Corp,Materials
+BAC,Bank of America,Financials
+BBWI,Bath & Body Works Inc.,Consumer Discretionary
+BAX,Baxter International,Health Care
+BDX,Becton Dickinson,Health Care
+BRK.B,Berkshire Hathaway,Financials
+BBY,Best Buy,Consumer Discretionary
+BIO,Bio-Rad Laboratories,Health Care
+TECH,Bio-Techne,Health Care
+BIIB,Biogen,Health Care
+BLK,BlackRock,Financials
+BK,BNY Mellon,Financials
+BA,Boeing,Industrials
+BKNG,Booking Holdings,Consumer Discretionary
+BWA,BorgWarner,Consumer Discretionary
+BXP,Boston Properties,Real Estate
+BSX,Boston Scientific,Health Care
+BMY,Bristol Myers Squibb,Health Care
+AVGO,Broadcom,Information Technology
+BR,Broadridge Financial Solutions,Information Technology
+BRO,Brown & Brown,Financials
+BF.B,Brown–Forman,Consumer Staples
+CHRW,C. H. Robinson,Industrials
+CDNS,Cadence Design Systems,Information Technology
+CZR,Caesars Entertainment,Consumer Discretionary
+CPB,Campbell Soup,Consumer Staples
+COF,Capital One Financial,Financials
+CAH,Cardinal Health,Health Care
+KMX,CarMax,Consumer Discretionary
+CCL,Carnival Corporation,Consumer Discretionary
+CARR,Carrier Global,Industrials
+CTLT,Catalent,Health Care
+CAT,Caterpillar,Industrials
+CBOE,Cboe Global Markets,Financials
+CBRE,CBRE,Real Estate
+CDW,CDW,Information Technology
+CE,Celanese,Materials
+CNC,Centene Corporation,Health Care
+CNP,CenterPoint Energy,Utilities
+CDAY,Ceridian,Information Technology
+CERN,Cerner,Health Care
+CF,CF Industries,Materials
+CRL,Charles River Laboratories,Health Care
+SCHW,Charles Schwab Corporation,Financials
+CHTR,Charter Communications,Communication Services
+CVX,Chevron Corporation,Energy
+CMG,Chipotle Mexican Grill,Consumer Discretionary
+CB,Chubb,Financials
+CHD,Church & Dwight,Consumer Staples
+CI,Cigna,Health Care
+CINF,Cincinnati Financial,Financials
+CTAS,Cintas Corporation,Industrials
+CSCO,Cisco Systems,Information Technology
+C,Citigroup,Financials
+CFG,Citizens Financial Group,Financials
+CTXS,Citrix Systems,Information Technology
+CLX,Clorox,Consumer Staples
+CME,CME Group,Financials
+CMS,CMS Energy,Utilities
+KO,Coca-Cola Company,Consumer Staples
+CTSH,Cognizant Technology Solutions,Information Technology
+CL,Colgate-Palmolive,Consumer Staples
+CMCSA,Comcast,Communication Services
+CMA,Comerica,Financials
+CAG,Conagra Brands,Consumer Staples
+COP,ConocoPhillips,Energy
+ED,Consolidated Edison,Utilities
+STZ,Constellation Brands,Consumer Staples
+CPRT,Copart,Industrials
+GLW,Corning,Information Technology
+CTVA,Corteva,Materials
+COST,Costco,Consumer Staples
+CTRA,Coterra,Energy
+CCI,Crown Castle,Real Estate
+CSX,CSX,Industrials
+CMI,Cummins,Industrials
+CVS,CVS Health,Health Care
+DHI,D. R. Horton,Consumer Discretionary
+DHR,Danaher Corporation,Health Care
+DRI,Darden Restaurants,Consumer Discretionary
+DVA,DaVita,Health Care
+DE,Deere & Co.,Industrials
+DAL,Delta Air Lines,Industrials
+XRAY,Dentsply Sirona,Health Care
+DVN,Devon Energy,Energy
+DXCM,DexCom,Health Care
+FANG,Diamondback Energy,Energy
+DLR,Digital Realty Trust,Real Estate
+DFS,Discover Financial Services,Financials
+DISCA,Discovery (Series A),Communication Services
+DISCK,Discovery (Series C),Communication Services
+DISH,Dish Network,Communication Services
+DG,Dollar General,Consumer Discretionary
+DLTR,Dollar Tree,Consumer Discretionary
+D,Dominion Energy,Utilities
+DPZ,Domino's Pizza,Consumer Discretionary
+DOV,Dover Corporation,Industrials
+DOW,Dow,Materials
+DTE,DTE Energy,Utilities
+DUK,Duke Energy,Utilities
+DRE,Duke Realty Corp,Real Estate
+DD,DuPont,Materials
+DXC,DXC Technology,Information Technology
+EMN,Eastman Chemical,Materials
+ETN,Eaton Corporation,Industrials
+EBAY,eBay,Consumer Discretionary
+ECL,Ecolab,Materials
+EIX,Edison International,Utilities
+EW,Edwards Lifesciences,Health Care
+EA,Electronic Arts,Communication Services
+LLY,Eli Lilly & Co,Health Care
+EMR,Emerson Electric Company,Industrials
+ENPH,Enphase Energy,Information Technology
+ETR,Entergy,Utilities
+EOG,EOG Resources,Energy
+EFX,Equifax,Industrials
+EQIX,Equinix,Real Estate
+EQR,Equity Residential,Real Estate
+ESS,Essex Property Trust,Real Estate
+EL,Estée Lauder Companies,Consumer Staples
+ETSY,Etsy,Consumer Discretionary
+RE,Everest Re,Financials
+EVRG,Evergy,Utilities
+ES,Eversource Energy,Utilities
+EXC,Exelon,Utilities
+EXPE,Expedia Group,Consumer Discretionary
+EXPD,Expeditors,Industrials
+EXR,Extra Space Storage,Real Estate
+XOM,ExxonMobil,Energy
+FFIV,F5 Networks,Information Technology
+FB,Facebook,Communication Services
+FAST,Fastenal,Industrials
+FRT,Federal Realty Investment Trust,Real Estate
+FDX,FedEx,Industrials
+FIS,Fidelity National Information Services,Information Technology
+FITB,Fifth Third Bancorp,Financials
+FRC,First Republic Bank,Financials
+FE,FirstEnergy,Utilities
+FISV,Fiserv,Information Technology
+FLT,Fleetcor,Information Technology
+FMC,FMC Corporation,Materials
+F,Ford,Consumer Discretionary
+FTNT,Fortinet,Information Technology
+FTV,Fortive,Industrials
+FBHS,Fortune Brands Home & Security,Industrials
+FOXA,Fox Corporation (Class A),Communication Services
+FOX,Fox Corporation (Class B),Communication Services
+BEN,Franklin Resources,Financials
+FCX,Freeport-McMoRan,Materials
+GPS,Gap,Consumer Discretionary
+GRMN,Garmin,Consumer Discretionary
+IT,Gartner,Information Technology
+GNRC,Generac Holdings,Industrials
+GD,General Dynamics,Industrials
+GE,General Electric,Industrials
+GIS,General Mills,Consumer Staples
+GM,General Motors,Consumer Discretionary
+GPC,Genuine Parts,Consumer Discretionary
+GILD,Gilead Sciences,Health Care
+GPN,Global Payments,Information Technology
+GL,Globe Life,Financials
+GS,Goldman Sachs,Financials
+HAL,Halliburton,Energy
+HBI,Hanesbrands,Consumer Discretionary
+HAS,Hasbro,Consumer Discretionary
+HCA,HCA Healthcare,Health Care
+PEAK,Healthpeak Properties,Real Estate
+HSIC,Henry Schein,Health Care
+HES,Hess Corporation,Energy
+HPE,Hewlett Packard Enterprise,Information Technology
+HLT,Hilton Worldwide,Consumer Discretionary
+HOLX,Hologic,Health Care
+HD,Home Depot,Consumer Discretionary
+HON,Honeywell,Industrials
+HRL,Hormel,Consumer Staples
+HST,Host Hotels & Resorts,Real Estate
+HWM,Howmet Aerospace,Industrials
+HPQ,HP,Information Technology
+HUM,Humana,Health Care
+HBAN,Huntington Bancshares,Financials
+HII,Huntington Ingalls Industries,Industrials
+IBM,IBM,Information Technology
+IEX,IDEX Corporation,Industrials
+IDXX,Idexx Laboratories,Health Care
+INFO,IHS Markit,Industrials
+ITW,Illinois Tool Works,Industrials
+ILMN,Illumina,Health Care
+INCY,Incyte,Health Care
+IR,Ingersoll Rand,Industrials
+INTC,Intel,Information Technology
+ICE,Intercontinental Exchange,Financials
+IFF,International Flavors & Fragrances,Materials
+IP,International Paper,Materials
+IPG,Interpublic Group,Communication Services
+INTU,Intuit,Information Technology
+ISRG,Intuitive Surgical,Health Care
+IVZ,Invesco,Financials
+IPGP,IPG Photonics,Information Technology
+IQV,IQVIA,Health Care
+IRM,Iron Mountain,Real Estate
+JBHT,J. B. Hunt,Industrials
+JKHY,Jack Henry & Associates,Information Technology
+J,Jacobs Engineering Group,Industrials
+SJM,JM Smucker,Consumer Staples
+JNJ,Johnson & Johnson,Health Care
+JCI,Johnson Controls,Industrials
+JPM,JPMorgan Chase,Financials
+JNPR,Juniper Networks,Information Technology
+KSU,Kansas City Southern,Industrials
+K,Kellogg's,Consumer Staples
+KEY,KeyCorp,Financials
+KEYS,Keysight Technologies,Information Technology
+KMB,Kimberly-Clark,Consumer Staples
+KIM,Kimco Realty,Real Estate
+KMI,Kinder Morgan,Energy
+KLAC,KLA Corporation,Information Technology
+KHC,Kraft Heinz,Consumer Staples
+KR,Kroger,Consumer Staples
+LHX,L3Harris Technologies,Industrials
+LH,LabCorp,Health Care
+LRCX,Lam Research,Information Technology
+LW,Lamb Weston,Consumer Staples
+LVS,Las Vegas Sands,Consumer Discretionary
+LEG,Leggett & Platt,Consumer Discretionary
+LDOS,Leidos,Industrials
+LEN,Lennar,Consumer Discretionary
+LNC,Lincoln National,Financials
+LIN,Linde,Materials
+LYV,Live Nation Entertainment,Communication Services
+LKQ,LKQ Corporation,Consumer Discretionary
+LMT,Lockheed Martin,Industrials
+L,Loews Corporation,Financials
+LOW,Lowe's,Consumer Discretionary
+LUMN,Lumen Technologies,Communication Services
+LYB,LyondellBasell,Materials
+MTB,M&T Bank,Financials
+MRO,Marathon Oil,Energy
+MPC,Marathon Petroleum,Energy
+MKTX,MarketAxess,Financials
+MAR,Marriott International,Consumer Discretionary
+MMC,Marsh & McLennan,Financials
+MLM,Martin Marietta Materials,Materials
+MAS,Masco,Industrials
+MA,Mastercard,Information Technology
+MTCH,Match Group,Communication Services
+MKC,McCormick & Company,Consumer Staples
+MCD,McDonald's,Consumer Discretionary
+MCK,McKesson Corporation,Health Care
+MDT,Medtronic,Health Care
+MRK,Merck & Co.,Health Care
+MET,MetLife,Financials
+MTD,Mettler Toledo,Health Care
+MGM,MGM Resorts International,Consumer Discretionary
+MCHP,Microchip Technology,Information Technology
+MU,Micron Technology,Information Technology
+MSFT,Microsoft,Information Technology
+MAA,Mid-America Apartments,Real Estate
+MRNA,Moderna,Health Care
+MHK,Mohawk Industries,Consumer Discretionary
+TAP,Molson Coors Beverage Company,Consumer Staples
+MDLZ,Mondelez International,Consumer Staples
+MPWR,Monolithic Power Systems,Information Technology
+MNST,Monster Beverage,Consumer Staples
+MCO,Moody's Corporation,Financials
+MS,Morgan Stanley,Financials
+MSI,Motorola Solutions,Information Technology
+MSCI,MSCI,Financials
+NDAQ,Nasdaq,Financials
+NTAP,NetApp,Information Technology
+NFLX,Netflix,Communication Services
+NWL,Newell Brands,Consumer Discretionary
+NEM,Newmont,Materials
+NWSA,News Corp (Class A),Communication Services
+NWS,News Corp (Class B),Communication Services
+NEE,NextEra Energy,Utilities
+NLSN,Nielsen Holdings,Industrials
+NKE,Nike,Consumer Discretionary
+NI,NiSource,Utilities
+NSC,Norfolk Southern,Industrials
+NTRS,Northern Trust,Financials
+NOC,Northrop Grumman,Industrials
+NLOK,NortonLifeLock,Information Technology
+NCLH,Norwegian Cruise Line Holdings,Consumer Discretionary
+NRG,NRG Energy,Utilities
+NUE,Nucor,Materials
+NVDA,Nvidia,Information Technology
+NVR,NVR,Consumer Discretionary
+NXPI,NXP,Information Technology
+ORLY,O'Reilly Automotive,Consumer Discretionary
+OXY,Occidental Petroleum,Energy
+ODFL,Old Dominion Freight Line,Industrials
+OMC,Omnicom Group,Communication Services
+OKE,Oneok,Energy
+ORCL,Oracle,Information Technology
+OGN,Organon & Co.,Health Care
+OTIS,Otis Worldwide,Industrials
+PCAR,Paccar,Industrials
+PKG,Packaging Corporation of America,Materials
+PH,Parker-Hannifin,Industrials
+PAYX,Paychex,Information Technology
+PAYC,Paycom,Information Technology
+PYPL,PayPal,Information Technology
+PENN,Penn National Gaming,Consumer Discretionary
+PNR,Pentair,Industrials
+PBCT,People's United Financial,Financials
+PEP,PepsiCo,Consumer Staples
+PKI,PerkinElmer,Health Care
+PFE,Pfizer,Health Care
+PM,Philip Morris International,Consumer Staples
+PSX,Phillips 66,Energy
+PNW,Pinnacle West Capital,Utilities
+PXD,Pioneer Natural Resources,Energy
+PNC,PNC Financial Services,Financials
+POOL,Pool Corporation,Consumer Discretionary
+PPG,PPG Industries,Materials
+PPL,PPL,Utilities
+PFG,Principal Financial Group,Financials
+PG,Procter & Gamble,Consumer Staples
+PGR,Progressive Corporation,Financials
+PLD,Prologis,Real Estate
+PRU,Prudential Financial,Financials
+PTC,PTC,Information Technology
+PEG,Public Service Enterprise Group,Utilities
+PSA,Public Storage,Real Estate
+PHM,PulteGroup,Consumer Discretionary
+PVH,PVH,Consumer Discretionary
+QRVO,Qorvo,Information Technology
+QCOM,Qualcomm,Information Technology
+PWR,Quanta Services,Industrials
+DGX,Quest Diagnostics,Health Care
+RL,Ralph Lauren Corporation,Consumer Discretionary
+RJF,Raymond James Financial,Financials
+RTX,Raytheon Technologies,Industrials
+O,Realty Income Corporation,Real Estate
+REG,Regency Centers,Real Estate
+REGN,Regeneron Pharmaceuticals,Health Care
+RF,Regions Financial Corporation,Financials
+RSG,Republic Services,Industrials
+RMD,ResMed,Health Care
+RHI,Robert Half International,Industrials
+ROK,Rockwell Automation,Industrials
+ROL,Rollins,Industrials
+ROP,Roper Technologies,Industrials
+ROST,Ross Stores,Consumer Discretionary
+RCL,Royal Caribbean Group,Consumer Discretionary
+SPGI,S&P Global,Financials
+CRM,Salesforce,Information Technology
+SBAC,SBA Communications,Real Estate
+SLB,Schlumberger,Energy
+STX,Seagate Technology,Information Technology
+SEE,Sealed Air,Materials
+SRE,Sempra Energy,Utilities
+NOW,ServiceNow,Information Technology
+SHW,Sherwin-Williams,Materials
+SPG,Simon Property Group,Real Estate
+SWKS,Skyworks Solutions,Information Technology
+SNA,Snap-on,Industrials
+SO,Southern Company,Utilities
+LUV,Southwest Airlines,Industrials
+SWK,Stanley Black & Decker,Industrials
+SBUX,Starbucks,Consumer Discretionary
+STT,State Street Corporation,Financials
+STE,Steris,Health Care
+SYK,Stryker Corporation,Health Care
+SIVB,SVB Financial,Financials
+SYF,Synchrony Financial,Financials
+SNPS,Synopsys,Information Technology
+SYY,Sysco,Consumer Staples
+TMUS,T-Mobile US,Communication Services
+TROW,T. Rowe Price,Financials
+TTWO,Take-Two Interactive,Communication Services
+TPR,Tapestry,Consumer Discretionary
+TGT,Target Corporation,Consumer Discretionary
+TEL,TE Connectivity,Information Technology
+TDY,Teledyne Technologies,Industrials
+TFX,Teleflex,Health Care
+TER,Teradyne,Information Technology
+TSLA,Tesla,Consumer Discretionary
+TXN,Texas Instruments,Information Technology
+TXT,Textron,Industrials
+COO,The Cooper Companies,Health Care
+HIG,The Hartford,Financials
+HSY,The Hershey Company,Consumer Staples
+MOS,The Mosaic Company,Materials
+TRV,The Travelers Companies,Financials
+DIS,The Walt Disney Company,Communication Services
+TMO,Thermo Fisher Scientific,Health Care
+TJX,TJX Companies,Consumer Discretionary
+TSCO,Tractor Supply Company,Consumer Discretionary
+TT,Trane Technologies,Industrials
+TDG,TransDigm Group,Industrials
+TRMB,Trimble,Information Technology
+TFC,Truist Financial,Financials
+TWTR,Twitter,Communication Services
+TYL,Tyler Technologies,Information Technology
+TSN,Tyson Foods,Consumer Staples
+USB,U.S. Bancorp,Financials
+UDR,UDR,Real Estate
+ULTA,Ulta Beauty,Consumer Discretionary
+UAA,Under Armour (Class A),Consumer Discretionary
+UA,Under Armour (Class C),Consumer Discretionary
+UNP,Union Pacific,Industrials
+UAL,United Airlines,Industrials
+UPS,United Parcel Service,Industrials
+URI,United Rentals,Industrials
+UNH,UnitedHealth Group,Health Care
+UHS,Universal Health Services,Health Care
+VLO,Valero Energy,Energy
+VTR,Ventas,Real Estate
+VRSN,Verisign,Information Technology
+VRSK,Verisk Analytics,Industrials
+VZ,Verizon Communications,Communication Services
+VRTX,Vertex Pharmaceuticals,Health Care
+VFC,VF Corporation,Consumer Discretionary
+VIAC,ViacomCBS,Communication Services
+VTRS,Viatris,Health Care
+V,Visa,Information Technology
+VNO,Vornado Realty Trust,Real Estate
+VMC,Vulcan Materials,Materials
+WRB,W. R. Berkley Corporation,Financials
+GWW,W. W. Grainger,Industrials
+WAB,Wabtec,Industrials
+WBA,Walgreens Boots Alliance,Consumer Staples
+WMT,Walmart,Consumer Staples
+WM,Waste Management,Industrials
+WAT,Waters Corporation,Health Care
+WEC,WEC Energy Group,Utilities
+WFC,Wells Fargo,Financials
+WELL,Welltower,Real Estate
+WST,West Pharmaceutical Services,Health Care
+WDC,Western Digital,Information Technology
+WU,Western Union,Information Technology
+WRK,WestRock,Materials
+WY,Weyerhaeuser,Real Estate
+WHR,Whirlpool Corporation,Consumer Discretionary
+WMB,Williams Companies,Energy
+WLTW,Willis Towers Watson,Financials
+WYNN,Wynn Resorts,Consumer Discretionary
+XEL,Xcel Energy,Utilities
+XLNX,Xilinx,Information Technology
+XYL,Xylem,Industrials
+YUM,Yum! Brands,Consumer Discretionary
+ZBRA,Zebra Technologies,Information Technology
+ZBH,Zimmer Biomet,Health Care
+ZION,Zions Bancorp,Financials
+ZTS,Zoetis,Health Care

--- a/stock_scrapper.py
+++ b/stock_scrapper.py
@@ -3,13 +3,24 @@
     Author: Jonathan Birkey
     Email: jbirke2@illinois.edu
     Date created: 29 Oct 2021
-    Python Version: 3.8
+    Python Version: 3.10.0
+    Notes: S&P 500 company list pulled from https://datahub.io/core/s-and-p-500-companies#data
 """
+import datetime
+import pandas as pd
+import time
 
 
 def main():
-    """S&P 500 company list pulled from https://datahub.io/core/s-and-p-500-companies#data"""
-    print("Hello World")
+    ticker = 'MMM'
+    period1 = int(time.mktime(datetime.datetime(2020, 1, 1, 23, 59).timetuple()))
+    period2 = int(time.mktime(datetime.datetime(2020, 12, 31, 23, 59).timetuple()))
+    interval = '1d'  # daily = 1d, weekly = 1wk, monthly = 1m
+
+    query_str = f'https://query1.finance.yahoo.com/v7/finance/download/{ticker}?period1={period1}&' \
+                f'period2={period2}&interval={interval}&events=history&includeAdjustedClose=true'
+    df = pd.read_csv(query_str)
+    print(df)
 
 
 if __name__ == "__main__":

--- a/stock_scrapper.py
+++ b/stock_scrapper.py
@@ -6,12 +6,34 @@
     Python Version: 3.10.0
     Notes: S&P 500 company list pulled from https://datahub.io/core/s-and-p-500-companies#data
 """
+import csv
 import datetime
+import numpy as np
 import pandas as pd
 import time
 
 
+def get_sp500_tickers(file: str) -> list[str]:
+    tickers = []
+    with open(file, 'r', newline='') as csvfile:
+        reader = csv.reader(csvfile, delimiter=',')
+        next(reader, None)  # skip csv file headers
+        for i in reader:
+            tickers.append(i[0])
+    return tickers
+
+
+def calculate_daily_change_rate(df: pd.DataFrame) -> None:
+    df['Change'] = np.zeros((len(df)))
+    df['Change Rate'] = np.zeros((len(df)))
+    for i in df.index:
+        df['Change'].iloc[i] = (df['Close'].iloc[i] - df['Open'].iloc[i])
+        df['Change Rate'].iloc[i] = (df['Close'].iloc[i] - df['Open'].iloc[i]) / df['Open'].iloc[i] * 100
+
+
 def main():
+    file_path = 'data/sp_500_constituents_as_of_20211022.csv'
+    tickers = get_sp500_tickers(file_path)
     ticker = 'MMM'
     period1 = int(time.mktime(datetime.datetime(2020, 1, 1, 23, 59).timetuple()))
     period2 = int(time.mktime(datetime.datetime(2020, 12, 31, 23, 59).timetuple()))
@@ -19,8 +41,11 @@ def main():
 
     query_str = f'https://query1.finance.yahoo.com/v7/finance/download/{ticker}?period1={period1}&' \
                 f'period2={period2}&interval={interval}&events=history&includeAdjustedClose=true'
+
     df = pd.read_csv(query_str)
-    print(df)
+    calculate_daily_change_rate(df)
+
+    # TODO: calculate change and change rate for every ticker in the tickers list and save it as a single dataset
 
 
 if __name__ == "__main__":

--- a/stock_scrapper.py
+++ b/stock_scrapper.py
@@ -1,0 +1,16 @@
+"""
+    File name: stock_scrapper.py
+    Author: Jonathan Birkey
+    Email: jbirke2@illinois.edu
+    Date created: 29 Oct 2021
+    Python Version: 3.8
+"""
+
+
+def main():
+    """S&P 500 company list pulled from https://datahub.io/core/s-and-p-500-companies#data"""
+    print("Hello World")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds the initial stock_scrapper script and a csv of all the stocks in the S&P 500. The script starts by pulling all the daily price data for a given stock (right now its hard coded to MMM) and converts the returned data into a 2D pandas DataFrame. The script then adds and calculates two columns to the DataFrame. Those being "Change" with is the dollar amount change from the days open to close price, and "Change Rate" which is the percentage of price change from open to close. The csv file contains the stock's ticker symbol, stock name, and industry for all 500 stocks in the S&P 500.